### PR TITLE
edits

### DIFF
--- a/vignettes/vignette_vcf2dadi.Rmd
+++ b/vignettes/vignette_vcf2dadi.Rmd
@@ -52,7 +52,7 @@ setwd("~/Documents/vcf2dadi_example")
 ```
 
 ## Get the data and create a strata file
-1. Dataset: in this example, we use the data in Ferchaud et al. (2015 and 2016) 
+1. Dataset: in this example, we use the data in Ferchaud and Hansen (2015 and 2016) 
 paper.
 ```r
 # download the file:
@@ -73,9 +73,9 @@ The `STRATA` column can be any hierarchical grouping.
   function `stackr::individuals2strata`. 
   
     ```r
-    # here is one id: 
+    # here is one individual id: 
     Hadsten10_q_75.align
-    # with pop starting at position 1 and to keep only 3 character we stop at... 3
+    # with pop starting at position 1 and to keep only 3 characters (necessary to discriminate populations from each other) we stop at... 3
     ```
   
   * For info on the function use: `?individuals2strata`.
@@ -169,12 +169,11 @@ environment, it's only written to the working directory.
 
 ## Filtering the dataset before generating the ∂a∂i input file
 
-1. It make no sense to create a ∂a∂i input file with so many populations. If we
-wanted to keep just 3 populations: Had, Mos and Odd, we use the `pop.select` 
+1. It makes no sense to create a ∂a∂i input file with so many populations. If we
+want to keep just 3 populations: Had, Mos and Odd, we use the `pop.select` 
 argument.
-This is where the default argument `common.markers = TRUE` and 
-`monomorphic.out` becomes useful. They can be turned off with `FALSE`, 
-however this is not something I recommend. 
+This is where the default argument `common.markers = TRUE` becomes useful. It can be turned off with `FALSE`, 
+however this is not something I recommend since you should only use SNPs WITHOUT missing data.
 
     For the second 
 run of `stackr::vcf2dadi`, this time we also ask to generate a ∂a∂i input file with:
@@ -278,7 +277,7 @@ written to the working directory:
 
 ## Using an outgroup and generate the ∂a∂i input file
 
-To generate a  ∂a∂i input file with an outgroup, we currently need stacks output
+To generate a ∂a∂i input file with an outgroup, we currently need stacks output
 files in order to get the fasta and SNP position. 
 Very soon I'll make an update where you can feed the function a file
 containing all this info, making the function truly stacks-free. For those of


### PR DESCRIPTION
I would not put the default argument `monomorphic.out = TRUE`, at least I would not recommend to not turn `FALSE` the argument... since the nb of monomorphic is useful to get absolute estimation of timing events, also playing an important role in likelihood computations. see Laurent Excoffier's recommendations: https://groups.google.com/forum/#!searchin/fastsimcoal/impact$20of$20monomorphic/fastsimcoal/dkJ6P5y1ViY/Jn977V8EAwAJ
In the same way, I would not do any filtering for the MAF, ...we already discussed about that...If other filtering (paralogy, coverage, allelic imbalance...) have been accurately conducted there is no problem to keep SNPs with very very low frequency, they are INFORMATIVE to date a demographic event (see above)...but just keep it like that if willing
Good job !